### PR TITLE
Fix Assets group 'laravolt' not found in the config file

### DIFF
--- a/resources/views/layouts/base.blade.php
+++ b/resources/views/layouts/base.blade.php
@@ -12,7 +12,6 @@
     <link rel="stylesheet" type="text/css" href="{{ mix('css/all.css', 'laravolt') }}"/>
     @stack('style')
     @stack('head')
-    {!! Assets::group('laravolt')->css() !!}
     {!! Assets::css() !!}
 </head>
 
@@ -21,7 +20,6 @@
 @yield('body')
 
 <script type="text/javascript" src="{{ mix('js/all.js', 'laravolt') }}"></script>
-{!! Assets::group('laravolt')->js() !!}
 {!! Assets::js() !!}
 @stack('script')
 @stack('body')


### PR DESCRIPTION
Error found when there is no group laravolt in the assets config.
It appears on first installation.

![image](https://user-images.githubusercontent.com/8675936/56198050-4e68d500-6064-11e9-9044-6da17396e2ed.png)
